### PR TITLE
updates to full text functions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4 >= 4.6.3
 biopython >= 1.75
 crossref-commons >= 0.0.6
-dimcli >= 0.6.1
+dimcli >= 0.6.2
 requests >= 2.22.0
 requests-cache >= 0.5.2
 selenium >= 3.141.0

--- a/test.py
+++ b/test.py
@@ -25,6 +25,16 @@ class TestOpenAPIs (unittest.TestCase):
         self.assertTrue(repr(meta) == "OrderedDict([('url', 'https://europepmc.org/articles/PMC5574185/'), ('authors', ['Taillie, Lindsey Smith', 'Ng, Shu Wen', 'Xue, Ya', 'Harding, Matthew']), ('open', True)])")
 
 
+    def test_openaire_fulltext_search (self):
+        schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
+        search_term = "NHANES"
+        
+        meta = schol.openaire.full_text_search(search_term)
+
+        print("\ntime: {:.3f} ms - {}".format(schol.openaire.elapsed_time, schol.openaire.name))
+        self.assertTrue(len(meta) >= 3300)
+
+
     def test_crossref_publication_lookup (self):
         schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
         doi = "10.1503/cmaj.170880"


### PR DESCRIPTION
One use for full text searches is to generate potential publication-dataset linkages for manual validation by searching through text in literature repositories for dataset names.

Updates in this PR:
1. updated url for openaire to accommodate full text searches

2. created `parse_oa`, `parse_dimensions` and `parse_pubmed`, functions which parse/filter api responses to just the fields needed to validate linkages.  The parse functions are used in conjunction with full_text search functions -- an example using NOAA datasets for generating linkages can be found [here](https://github.com/NYU-CI/RCCustomers/blob/master/generating_linkages.ipynb).

NB: `parse_oa` will parse articles of two categories: "Other literature type" and "Article" (the title search still only looks at those of type "Article"). Added this bc I came across items in the openaire response that were 'other literature type', but appeared to just be regular research papers. For dimensions I allowed types "article" and "preprint", as came 
across a few papers in pre-print that are available online, like [this one](https://arxiv.org/abs/1912.01786) (but note that this particular example doesn't have a doi yet).

3. added an `nresults` parameter to full_text search functions so user 
can control # returns. Added this because many of the potential linkages for NOAA had over 1K entries. The default value for `nresults` is the max # returns for the api (1000 for dimensions, as many as exist for pubmed/oa).
4. updated requirements.txt to account for newer version of `dimcli`. Without newer version, dimensions functions throw an error because of the `verbose` argument to `dimcli.login()`