### PR TITLE
adding nresults arg and updating requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4 >= 4.6.3
 biopython >= 1.75
 crossref-commons >= 0.0.6
-dimcli >= 0.6.1
+dimcli >= 0.6.2
 requests >= 2.22.0
 requests-cache >= 0.5.2
 selenium >= 3.141.0

--- a/richcontext/scholapi/scholapi.py
+++ b/richcontext/scholapi/scholapi.py
@@ -649,7 +649,7 @@ class ScholInfra_PubMed (ScholInfra):
         t0 = time.time()
         
         Entrez.email = self.parent.config["DEFAULT"]["email"]
-        id_list  = fulltext_id_search(search_term)
+        id_list = self.fulltext_id_search(search_term)
         
         if id_list and len(id_list) > 0:
                 id_list = ",".join(id_list)

--- a/richcontext/scholapi/scholapi.py
+++ b/richcontext/scholapi/scholapi.py
@@ -330,14 +330,19 @@ class ScholInfra_Dimensions (ScholInfra):
         return None
 
 
-    def full_text_search (self, search_term,exact_match = True):
+    def full_text_search (self, search_term,exact_match = True,nresults = None):
         """
         parse metadata from a Dimensions API full-text search
         """
         t0 = time.time()
-        query = 'search publications in full_data_exact for "\\"{}\\"" return publications[all] limit 1000'.format(search_term)
-        if exact_match == False:
-            query = 'search publications in full_data_exact for "{}" return publications[doi+title+journal] limit 1000'.format(search_term)
+        if not nresults:
+            query = 'search publications in full_data_exact for "\\"{}\\"" return publications[all] limit 1000'.format(search_term)
+            if exact_match == False:
+                query = 'search publications in full_data_exact for "{}" return publications[all] limit 1000'.format(search_term)
+        if nresults:
+            query = 'search publications in full_data_exact for "\\"{}\\"" return publications[all] limit {}'.format(search_term,nresults)
+            if exact_match == False:
+                query = 'search publications in full_data_exact for "{}" return publications[all] limit {}'.format(search_term,nresults)
 
         self.login()
         response = self.run_query(query)
@@ -612,26 +617,35 @@ class ScholInfra_PubMed (ScholInfra):
             return None
 
 
-    def fulltext_id_search (self, search_term):
+    def fulltext_id_search (self, search_term, nresults = None):
         Entrez.email = self.parent.config["DEFAULT"]["email"]
 
         query_return = Entrez.read(Entrez.egquery(term="\"{}\"".format(search_term)))
         response_count = int([d for d in query_return["eGQueryResult"] if d["DbName"] == 'pubmed'][0]["Count"])
-
         if response_count > 0:
-            handle = Entrez.read(Entrez.esearch(db="pubmed",
-                                                retmax=response_count,
-                                                term="\"{}\"".format(search_term)
-                                                )
-                                 )
+            if nresults == None:
+                handle = Entrez.read(Entrez.esearch(db="pubmed",
+                                                    retmax=response_count,
+                                                    term="\"{}\"".format(search_term)
+                                                    )
+                                    )
 
-            id_list = handle["IdList"]
+                id_list = handle["IdList"]
+            if nresults != None and nresults > 0 and isinstance(nresults, int):
+                handle = Entrez.read(Entrez.esearch(db="pubmed",
+                                                    retmax=nresults,
+                                                    term="\"{}\"".format(search_term)
+                                                    )
+                                    )
+
+                id_list = handle["IdList"]
             return id_list
+            
         else:
             return None
 
 
-    def fulltext_search (self, search_term):
+    def full_text_search (self, search_term, nresults = None):
         t0 = time.time()
         
         Entrez.email = self.parent.config["DEFAULT"]["email"]

--- a/richcontext/scholapi/scholapi.py
+++ b/richcontext/scholapi/scholapi.py
@@ -330,17 +330,20 @@ class ScholInfra_Dimensions (ScholInfra):
         return None
 
 
-    def full_text_search (self, search_term,exact_match = True,nresults = None):
+    def full_text_search (self, search_term, exact_match = True, nresults = None):
         """
         parse metadata from a Dimensions API full-text search
         """
         t0 = time.time()
         if not nresults:
             query = 'search publications in full_data_exact for "\\"{}\\"" return publications[all] limit 1000'.format(search_term)
+
             if exact_match == False:
                 query = 'search publications in full_data_exact for "{}" return publications[all] limit 1000'.format(search_term)
+
         if nresults:
             query = 'search publications in full_data_exact for "\\"{}\\"" return publications[all] limit {}'.format(search_term,nresults)
+
             if exact_match == False:
                 query = 'search publications in full_data_exact for "{}" return publications[all] limit {}'.format(search_term,nresults)
 
@@ -621,7 +624,8 @@ class ScholInfra_PubMed (ScholInfra):
         Entrez.email = self.parent.config["DEFAULT"]["email"]
 
         query_return = Entrez.read(Entrez.egquery(term="\"{}\"".format(search_term)))
-        response_count = int([d for d in query_return["eGQueryResult"] if d["DbName"] == 'pubmed'][0]["Count"])
+        response_count = int([d for d in query_return["eGQueryResult"] if d["DbName"] == "pubmed"][0]["Count"])
+
         if response_count > 0:
             if nresults == None:
                 handle = Entrez.read(Entrez.esearch(db="pubmed",
@@ -631,6 +635,7 @@ class ScholInfra_PubMed (ScholInfra):
                                     )
 
                 id_list = handle["IdList"]
+
             if nresults != None and nresults > 0 and isinstance(nresults, int):
                 handle = Entrez.read(Entrez.esearch(db="pubmed",
                                                     retmax=nresults,


### PR DESCRIPTION
1. added an `nresults` parameter to full_text search functions so user
can control # returns. Added this because many of the potential linkages for NOAA had over 1K entries. The default value for nresults is the max # returns for the api (1000 for dimensions, as many as exist for pubmed).
2. updated requirements.txt to account for newer version of dimcli. Without newer version, dimensions functions throw an error because of the verbose argument to `dimcli.login()`