### PR TITLE
oa full text search, parsing functions

### DIFF
--- a/richcontext/scholapi/scholapi.py
+++ b/richcontext/scholapi/scholapi.py
@@ -174,7 +174,7 @@ class ScholInfra_OpenAIRE (ScholInfra):
         """
         t0 = time.time()
 
-        url = self.get_api_url(urllib.parse.quote(title))
+        url = self.get_api_url() + "title={}".format(urllib.parse.quote(title))
         response = requests.get(url).text
         soup = BeautifulSoup(response,  "html.parser")
 
@@ -197,6 +197,42 @@ class ScholInfra_OpenAIRE (ScholInfra):
         self.mark_time(t0)
         return None
 
+    def parse_oa (self, result):
+        if result.find("instancetype")["classname"] in ["Other literature type", "Article"]:
+            meta = OrderedDict()
+            result_title = self.get_xml_node_value(result, "title")
+            meta["title"] = result_title
+            if self.get_xml_node_value(result, "journal"):
+                meta["journal"] = self.get_xml_node_value(result, "journal")
+            meta["url"] = self.get_xml_node_value(result, "url")
+            meta["authors"] = [a.text for a in result.find_all("creator")]
+            meta["open"] = len(result.find_all("bestaccessright",  {"classid": "OPEN"})) > 0
+            return meta
+        else:
+            return None
+
+    def full_text_search (self, search_term,nresults = None):
+        """
+        parse metadata from XML returned from the OpenAIRE API query
+        """
+        t0 = time.time()
+        base_url = self.get_api_url() + "keywords={}".format(urllib.parse.quote(search_term))
+        
+        if nresults:
+            search_url = base_url + '&size={}'.format(nresults)
+
+        elif not nresults:
+            response = requests.get(base_url).text
+            soup = BeautifulSoup(response,  "html.parser")
+            nresults_response = int(soup.find("total").text)
+            search_url = base_url + '&size={}'.format(nresults_response)
+        
+        response = requests.get(search_url).text
+        soup = BeautifulSoup(response,  "html.parser")
+        pub_metadata = soup.find_all("oaf:result")
+        self.mark_time(t0)
+        return pub_metadata
+    
 
 class ScholInfra_SemanticScholar (ScholInfra):
     """
@@ -324,11 +360,32 @@ class ScholInfra_Dimensions (ScholInfra):
                     self.mark_time(t0)
 
                     if len(meta) > 0:
+                        self.mark_time(t0)
                         return meta
 
         self.mark_time(t0)
         return None
 
+    def parse_dimensions(self, result):
+        if result["type"] in ["article","preprint"]:
+            meta = OrderedDict()
+            meta["title"] = result["title"]
+            try:
+                meta["journal"] = result["journal"]["title"]
+            except:
+                pass
+            try:
+                meta["doi"] = result["doi"]
+            except:
+                pass
+            try:
+                author_list = result["authors"]
+                meta["authors"] = [b["last_name"] + ", " + b["first_name"] for b in author_list]
+            except:
+                pass
+            return meta
+        else:
+            return None
 
     def full_text_search (self, search_term,exact_match = True):
         """
@@ -342,10 +399,10 @@ class ScholInfra_Dimensions (ScholInfra):
         self.login()
         response = self.run_query(query)
         search_results = response.publications
-
+        
         self.mark_time(t0)
         return search_results
-
+        
 
 class ScholInfra_RePEc (ScholInfra):
     """
@@ -612,7 +669,7 @@ class ScholInfra_PubMed (ScholInfra):
             return None
 
 
-    def fulltext_id_search (self, search_term):
+    def full_text_id_search (self, search_term):
         Entrez.email = self.parent.config["DEFAULT"]["email"]
 
         query_return = Entrez.read(Entrez.egquery(term="\"{}\"".format(search_term)))
@@ -630,12 +687,36 @@ class ScholInfra_PubMed (ScholInfra):
         else:
             return None
 
+    def parse_pubmed(self, result):
+        article_meta = result["MedlineCitation"]["Article"]
+        meta = OrderedDict()
+        meta["title"] = article_meta["ArticleTitle"]
+        meta["journal"] = article_meta["Journal"]["Title"]
+        try:
+            if isinstance(article_meta["AuthorList"]["Author"],list):
+                meta["authors"] = [a["LastName"]+ ", " + a["ForeName"] for a in article_meta["AuthorList"]["Author"]]
+            if isinstance(article_meta["AuthorList"]["Author"],dict):
+                        meta["authors"] = article_meta["AuthorList"]["Author"]["LastName"]+ "," + article_meta["AuthorList"]["Author"]["ForeName"]
+        except:
+            meta["authors"] = ''
+        try:
+            pid_list = article_meta["ELocationID"]    
+            if isinstance(pid_list,list):
+                    doi_test = [d["#text"] for d in pid_list if d["@EIdType"] == "doi"]
+                    if len(doi_test) > 0:
+                        meta["doi"] = doi_test[0]
+            if isinstance(pid_list,dict):
+                if pid_list["@EIdType"] == "doi":
+                    meta["doi"] = pid_list["#text"]
+        except:
+            pass
+        return meta
 
-    def fulltext_search (self, search_term):
+    def full_text_search (self, search_term):
         t0 = time.time()
         
         Entrez.email = self.parent.config["DEFAULT"]["email"]
-        id_list  = fulltext_id_search(search_term)
+        id_list  = self.full_text_id_search(search_term)
         
         if id_list and len(id_list) > 0:
                 id_list = ",".join(id_list)
@@ -651,14 +732,11 @@ class ScholInfra_PubMed (ScholInfra):
                 xml = xmltodict.parse(data)
                 meta_list = json.loads(json.dumps(xml))
                 meta = meta_list["PubmedArticleSet"]["PubmedArticle"]
-
+                
                 self.mark_time(t0)
                 return meta
-            
-        else:
-            raise Exception("Input to fetch from PubMed is not a list of IDs") 
-        
 
+                        
     def journal_lookup (self, issn):
         """
         use the NCBI discovery service for ISSN lookup
@@ -737,7 +815,7 @@ class ScholInfraAPI:
         self.openaire = ScholInfra_OpenAIRE(
             parent=self,
             name="OpenAIRE",
-            api_url="http://api.openaire.eu/search/publications?title={}"
+            api_url="http://api.openaire.eu/search/publications?"
             )
 
         self.pubmed = ScholInfra_PubMed(

--- a/test.py
+++ b/test.py
@@ -23,7 +23,15 @@ class TestOpenAPIs (unittest.TestCase):
 
         print("\ntime: {:.3f} ms - {}".format(schol.openaire.elapsed_time, schol.openaire.name))
         self.assertTrue(repr(meta) == "OrderedDict([('url', 'https://europepmc.org/articles/PMC5574185/'), ('authors', ['Taillie, Lindsey Smith', 'Ng, Shu Wen', 'Xue, Ya', 'Harding, Matthew']), ('open', True)])")
+    
+    def test_openaire_fulltext_search (self):
+        schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
+        search_term = "NHANES"
+        
+        meta = schol.openaire.full_text_search(search_term)
 
+        print("\ntime: {:.3f} ms - {}".format(schol.openaire.elapsed_time, schol.openaire.name))
+        self.assertTrue(len(meta) >= 3300)
 
     def test_crossref_publication_lookup (self):
         schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
@@ -59,7 +67,7 @@ class TestOpenAPIs (unittest.TestCase):
         schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
         search_term = "NHANES"
 
-        meta = schol.pubmed.fulltext_id_search(search_term)
+        meta = schol.pubmed.full_text_id_search(search_term)
 
         print("\ntime: {:.3f} ms - {}".format(schol.pubmed.elapsed_time, schol.pubmed.name))
         self.assertTrue(len(meta) >= 6850)


### PR DESCRIPTION
1. added openaire `full_text_search` function (including an `nresults` arg); updated `api_url` for openaire to accommodate full text searches, updated openaire `title_search` to conform to new `api_url`.
2. updated name of pubmed full_text_search function to match the others
3. created `parse_oa`, `parse_dimensions` and `parse_pubmed`, which parse/filter api responses to just the fields needed to validate linkages. The parse functions are used in conjunction with `full_text_search` functions -- an example using NOAA datasets for generating linkages can be found [here](https://github.com/NYU-CI/RCCustomers/blob/master/generating_linkages.ipynb).

NB: parse_oa will parse articles of two categories: "Other literature type" and "Article" (the title search still only looks at those of type "Article"). Added this bc I came across items in the openaire response that were 'other literature type', but appeared to just be regular research papers. For dimensions I allowed types "article" and "preprint", as came
across a few papers in pre-print that are available online, like [this one](https://arxiv.org/abs/1912.01786) (but note that this particular example doesn't have a doi yet).
