### PR TITLE
parsing functions

### DIFF
--- a/richcontext/scholapi/scholapi.py
+++ b/richcontext/scholapi/scholapi.py
@@ -346,7 +346,6 @@ class ScholInfra_Dimensions (ScholInfra):
                     self.mark_time(t0)
 
                     if len(meta) > 0:
-                        self.mark_time(t0)
                         return meta
 
         self.mark_time(t0)

--- a/richcontext/scholapi/scholapi.py
+++ b/richcontext/scholapi/scholapi.py
@@ -174,7 +174,7 @@ class ScholInfra_OpenAIRE (ScholInfra):
         """
         t0 = time.time()
 
-        url = self.get_api_url(urllib.parse.quote(title))
+        url = self.get_api_url() + "title={}".format(urllib.parse.quote(title))
         response = requests.get(url).text
         soup = BeautifulSoup(response,  "html.parser")
 
@@ -197,6 +197,28 @@ class ScholInfra_OpenAIRE (ScholInfra):
         self.mark_time(t0)
         return None
 
+    def full_text_search (self, search_term,nresults = None):
+        """
+        parse metadata from XML returned from the OpenAIRE API query
+        """
+        t0 = time.time()
+        base_url = self.get_api_url() + "keywords={}".format(urllib.parse.quote(search_term))
+        
+        if nresults:
+            search_url = base_url + '&size={}'.format(nresults)
+
+        elif not nresults:
+            response = requests.get(base_url).text
+            soup = BeautifulSoup(response,  "html.parser")
+            nresults_response = int(soup.find("total").text)
+            search_url = base_url + '&size={}'.format(nresults_response)
+        
+        response = requests.get(search_url).text
+        soup = BeautifulSoup(response,  "html.parser")
+        pub_metadata = soup.find_all("oaf:result")
+        self.mark_time(t0)
+        return pub_metadata
+    
 
 class ScholInfra_SemanticScholar (ScholInfra):
     """
@@ -324,36 +346,29 @@ class ScholInfra_Dimensions (ScholInfra):
                     self.mark_time(t0)
 
                     if len(meta) > 0:
+                        self.mark_time(t0)
                         return meta
 
         self.mark_time(t0)
         return None
 
 
-    def full_text_search (self, search_term, exact_match = True, nresults = None):
+    def full_text_search (self, search_term,exact_match = True):
         """
         parse metadata from a Dimensions API full-text search
         """
         t0 = time.time()
-        if not nresults:
-            query = 'search publications in full_data_exact for "\\"{}\\"" return publications[all] limit 1000'.format(search_term)
-
-            if exact_match == False:
-                query = 'search publications in full_data_exact for "{}" return publications[all] limit 1000'.format(search_term)
-
-        if nresults:
-            query = 'search publications in full_data_exact for "\\"{}\\"" return publications[all] limit {}'.format(search_term,nresults)
-
-            if exact_match == False:
-                query = 'search publications in full_data_exact for "{}" return publications[all] limit {}'.format(search_term,nresults)
+        query = 'search publications in full_data_exact for "\\"{}\\"" return publications[all] limit 1000'.format(search_term)
+        if exact_match == False:
+            query = 'search publications in full_data_exact for "{}" return publications[doi+title+journal] limit 1000'.format(search_term)
 
         self.login()
         response = self.run_query(query)
         search_results = response.publications
-
+        
         self.mark_time(t0)
         return search_results
-
+        
 
 class ScholInfra_RePEc (ScholInfra):
     """
@@ -620,41 +635,31 @@ class ScholInfra_PubMed (ScholInfra):
             return None
 
 
-    def fulltext_id_search (self, search_term, nresults = None):
+    def full_text_id_search (self, search_term):
         Entrez.email = self.parent.config["DEFAULT"]["email"]
 
         query_return = Entrez.read(Entrez.egquery(term="\"{}\"".format(search_term)))
-        response_count = int([d for d in query_return["eGQueryResult"] if d["DbName"] == "pubmed"][0]["Count"])
+        response_count = int([d for d in query_return["eGQueryResult"] if d["DbName"] == 'pubmed'][0]["Count"])
 
         if response_count > 0:
-            if nresults == None:
-                handle = Entrez.read(Entrez.esearch(db="pubmed",
-                                                    retmax=response_count,
-                                                    term="\"{}\"".format(search_term)
-                                                    )
-                                    )
+            handle = Entrez.read(Entrez.esearch(db="pubmed",
+                                                retmax=response_count,
+                                                term="\"{}\"".format(search_term)
+                                                )
+                                 )
 
-                id_list = handle["IdList"]
-
-            if nresults != None and nresults > 0 and isinstance(nresults, int):
-                handle = Entrez.read(Entrez.esearch(db="pubmed",
-                                                    retmax=nresults,
-                                                    term="\"{}\"".format(search_term)
-                                                    )
-                                    )
-
-                id_list = handle["IdList"]
+            id_list = handle["IdList"]
             return id_list
-            
         else:
             return None
 
 
-    def full_text_search (self, search_term, nresults = None):
+
+    def full_text_search (self, search_term):
         t0 = time.time()
         
         Entrez.email = self.parent.config["DEFAULT"]["email"]
-        id_list = self.fulltext_id_search(search_term)
+        id_list  = self.full_text_id_search(search_term)
         
         if id_list and len(id_list) > 0:
                 id_list = ",".join(id_list)
@@ -670,14 +675,11 @@ class ScholInfra_PubMed (ScholInfra):
                 xml = xmltodict.parse(data)
                 meta_list = json.loads(json.dumps(xml))
                 meta = meta_list["PubmedArticleSet"]["PubmedArticle"]
-
+                
                 self.mark_time(t0)
                 return meta
-            
-        else:
-            raise Exception("Input to fetch from PubMed is not a list of IDs") 
-        
 
+                        
     def journal_lookup (self, issn):
         """
         use the NCBI discovery service for ISSN lookup
@@ -756,7 +758,7 @@ class ScholInfraAPI:
         self.openaire = ScholInfra_OpenAIRE(
             parent=self,
             name="OpenAIRE",
-            api_url="http://api.openaire.eu/search/publications?title={}"
+            api_url="http://api.openaire.eu/search/publications?"
             )
 
         self.pubmed = ScholInfra_PubMed(

--- a/richcontext/scholapi/scholapi.py
+++ b/richcontext/scholapi/scholapi.py
@@ -359,7 +359,8 @@ class ScholInfra_Dimensions (ScholInfra):
         """
         t0 = time.time()
         if not nresults:
-        
+            query = 'search publications in full_data_exact for "\\"{}\\"" return publications[all] limit 1000'.format(search_term)
+
             if exact_match == False:
                 query = 'search publications in full_data_exact for "{}" return publications[all] limit 1000'.format(search_term)
     
@@ -643,7 +644,7 @@ class ScholInfra_PubMed (ScholInfra):
             return None
 
 
-    def full_text_id_search (self, search_term, nresults = None):
+    def fulltext_id_search (self, search_term, nresults = None):
         Entrez.email = self.parent.config["DEFAULT"]["email"]
 
         query_return = Entrez.read(Entrez.egquery(term="\"{}\"".format(search_term)))
@@ -679,7 +680,7 @@ class ScholInfra_PubMed (ScholInfra):
         t0 = time.time()
         
         Entrez.email = self.parent.config["DEFAULT"]["email"]
-        id_list = self.full_text_id_search(search_term)
+        id_list = self.fulltext_id_search(search_term)
         
         if id_list and len(id_list) > 0:
                 id_list = ",".join(id_list)

--- a/test.py
+++ b/test.py
@@ -23,7 +23,15 @@ class TestOpenAPIs (unittest.TestCase):
 
         print("\ntime: {:.3f} ms - {}".format(schol.openaire.elapsed_time, schol.openaire.name))
         self.assertTrue(repr(meta) == "OrderedDict([('url', 'https://europepmc.org/articles/PMC5574185/'), ('authors', ['Taillie, Lindsey Smith', 'Ng, Shu Wen', 'Xue, Ya', 'Harding, Matthew']), ('open', True)])")
+    
+    def test_openaire_fulltext_search (self):
+        schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
+        search_term = "NHANES"
+        
+        meta = schol.openaire.full_text_search(search_term)
 
+        print("\ntime: {:.3f} ms - {}".format(schol.openaire.elapsed_time, schol.openaire.name))
+        self.assertTrue(len(meta) >= 3300)
 
     def test_crossref_publication_lookup (self):
         schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
@@ -59,7 +67,7 @@ class TestOpenAPIs (unittest.TestCase):
         schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
         search_term = "NHANES"
 
-        meta = schol.pubmed.fulltext_id_search(search_term)
+        meta = schol.pubmed.full_text_id_search(search_term)
 
         print("\ntime: {:.3f} ms - {}".format(schol.pubmed.elapsed_time, schol.pubmed.name))
         self.assertTrue(len(meta) >= 6850)

--- a/test.py
+++ b/test.py
@@ -67,7 +67,7 @@ class TestOpenAPIs (unittest.TestCase):
         schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
         search_term = "NHANES"
 
-        meta = schol.pubmed.full_text_id_search(search_term)
+        meta = schol.pubmed.fulltext_id_search(search_term)
 
         print("\ntime: {:.3f} ms - {}".format(schol.pubmed.elapsed_time, schol.pubmed.name))
         self.assertTrue(len(meta) >= 6850)


### PR DESCRIPTION
Paco - I know we will meet to talk about the architecture for these accessory functions - I had this lumped in with an open aire full text search PR, so I wanted to separate the parsing functions out.

created `parse_oa`, `parse_dimensions` and `parse_pubmed`, which parse/filter api responses to just the fields needed to validate linkages. The parse functions are used in conjunction with full_text_search functions -- an example using NOAA datasets for generating linkages can be found here.
NB: `parse_oa` will parse articles of two categories: "Other literature type" and "Article" (the title search still only looks at those of type "Article"). Added this bc I came across items in the openaire response that were 'other literature type', but appeared to just be regular research papers. For dimensions I allowed types "article" and "preprint", as came
across a few papers in pre-print that are available online, like [this](https://arxiv.org/abs/1912.01786) one (but note that this particular example doesn't have a doi yet).